### PR TITLE
Prepare for release 3.2.1

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -8,6 +8,8 @@
 *Credit Card Number* is a Java library that can provide details of a bank issued
 credit card number.
 
+(Also see [Magnetic Track Parser](https://github.com/sualeh/magnetictrackparser).)
+
 
 ## Resources
 
@@ -106,3 +108,4 @@ and you will get this output:
 ```
 5266092201416174
 ```
+git

--- a/.github/workflows/quick_build.yml
+++ b/.github/workflows/quick_build.yml
@@ -1,6 +1,6 @@
 name: Quick Build
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build:

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>us.fatehi</groupId>
   <artifactId>creditcardnumber</artifactId>
-  <version>3.1.2</version>
+  <version>3.2.1</version>
   <packaging>jar</packaging>
   <name>Credit Card Number</name>
   <description>Credit Card Number is a library that can provide details of a bank issued credit card number. All classes are immutable and thread-safe. The standard `toString()` function formats data in a readable form.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>us.fatehi</groupId>
   <artifactId>creditcardnumber</artifactId>
-  <version>3.1.1</version>
+  <version>3.1.2</version>
   <packaging>jar</packaging>
   <name>Credit Card Number</name>
   <description>Credit Card Number is a library that can provide details of a bank issued credit card number. All classes are immutable and thread-safe. The standard `toString()` function formats data in a readable form.</description>

--- a/src/main/java/us/fatehi/creditcardnumber/AccountNumberComplete.java
+++ b/src/main/java/us/fatehi/creditcardnumber/AccountNumberComplete.java
@@ -38,7 +38,7 @@ final class AccountNumberComplete extends BaseRawData implements AccountNumber {
         MajorIndustryIdentifier.from(accountNumberString);
     final CardBrand cardBrand = CardBrand.from(accountNumberString);
     final int accountNumberLength = accountNumberString.length();
-    final boolean isLengthValid = Arrays.asList(13, 14, 15, 16, 19).contains(accountNumberLength);
+    final boolean isLengthValid = cardBrand.isLengthValid(accountNumberLength);
     final boolean isPrimaryAccountNumberValid =
         isLengthValid && passesLuhnCheck && cardBrand != CardBrand.Unknown;
     final boolean exceedsMaximumLength = accountNumberLength > 19;

--- a/src/main/java/us/fatehi/creditcardnumber/CardBrand.java
+++ b/src/main/java/us/fatehi/creditcardnumber/CardBrand.java
@@ -61,6 +61,9 @@ public enum CardBrand {
   // UnionPay numbers start with 62
   UnionPay("^62[0-9]{2,}$", new LengthRangeCheck(16, 19)),
 
+  // RuPay numbers start with 60, 6521, or 6522
+  RuPay("^(?:60[0-9]{2}|6521|6522)[0-9]*$", new LengthCheck(16)),
+
   // Diners Club card numbers begin with 300 through 305, 36 or 38
   DinersClub("^3(?:0[0-5]|[68][0-9])[0-9]{1,}$", new LengthRangeCheck(14, 19)),
 

--- a/src/main/java/us/fatehi/creditcardnumber/CardBrand.java
+++ b/src/main/java/us/fatehi/creditcardnumber/CardBrand.java
@@ -12,37 +12,117 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import java.util.regex.Pattern;
 
 /**
- * Card network that issued the bank card.
+ * Card network that issued the bank card. Attempt to do a best-guess at the card brand by just the
+ * first four digits of a card number, to allow for type-ahead logic. A slightly fuller check is
+ * done by checking if the number of digits is right (length check). Additionally, a Luhn check is
+ * done on the account number as well.
  *
- * <p>See <a href= "http://www.regular-expressions.info/creditcard.html">Finding or Verifying Credit
- * Card Numbers</a> See <a href=
+ * <p>
+ * See:
+ * <ul>
+ * <li><a href= "http://www.regular-expressions.info/creditcard.html">Finding or Verifying Credit
+ * Card Numbers</a></li>
+ * <li><a href=
  * "http://stackoverflow.com/questions/72768/how-do-you-detect-credit-card-type-based-on-number">How
- * do you detect Credit card type based on number?</a>
+ * do you detect Credit card type based on number?</a></li
+ * </ul>
  *
  * @author Sualeh Fatehi
  */
 public enum CardBrand {
-  Unknown("^unknown$"),
-  // Visa can be 13, 16 or 19 digits in length.
-  Visa("^4[0-9]{12}(?:[0-9]{3}){0,2}$"),
+  Unknown("^unknown$", new Predicate<Integer>() {
+
+    @Override
+    public boolean test(final Integer length) {
+      return length > 6;
+    }
+  }),
+
+  // Visa numbers start with 4
+  Visa("^4[0-9]{3,}$", new LengthCheck(13, 16, 19)),
+
   // MasterCard numbers start with the numbers 51 through 55, and 2221
-  // through 2720.
-  MasterCard("^(?:5[1-5][0-9]{2}|222[1-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12}$"),
-  AmericanExpress("^3[47][0-9]{13}$"),
-  // Discover can be 16 or 19 digits in length.
-  Discover("^6(?:011|5[0-9]{2})[0-9]{12}(?:[0-9]{3})?$"),
+  // through 2720
+  MasterCard("^(?:5[1-5][0-9]{2}|222[1-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]*$",
+      new LengthCheck(16)),
+
+  // American Express numbers start with 35 or 37
+  AmericanExpress("^3[47][0-9]{2,}$", new LengthCheck(15)),
+
+  // Discover numbers start with 6011 or 65 (though Discover also processes for other
+  // networks such as UnionPay)
+  // See
+  // https://web.archive.org/web/20170822221741/https://www.discovernetwork.com/downloads/IPP_VAR_Compliance.pdf
+  Discover("^6(?:011|5[0-9]{3})[0-9]*$", new LengthCheck(16, 19)),
+
   // MIR can be 16-19 digits in length.
-  MIR("^220[0-4][0-9]{12,15}$"),
-  // China Unionpay can be 16 or 19 digits in length.
-  UnionPay("^62[0-9]{14}(?:[0-9]{3})?$"),
-  // Diners Club card numbers begin with 300 through 305, 36 or 38.
-  DinersClub("^3(?:0[0-5]|[68][0-9])[0-9]{11}$"),
-  // Maestro can be 12-19 digits in length.
-  Maestro("^(?:5018|5020|5038|5893|6304|6759|676[1-3])[0-9]{8,15}$"),
-  // JCB can begin with 1800 or 2100 and be 15 digits in length, or JCB can begin with 35 and be 16-19
-  // digits in length.
-  JCB("^(?:2100|1800|35[0-9]{3,6})[0-9]{11}$"),
-  UATP("^1[0-9]{14}$");
+  MIR("^220[0-4][0-9]*$", new LengthRangeCheck(16, 19)),
+
+  // UnionPay numbers start with 62
+  UnionPay("^62[0-9]{2,}$", new LengthRangeCheck(16, 19)),
+
+  // Diners Club card numbers begin with 300 through 305, 36 or 38
+  DinersClub("^3(?:0[0-5]|[68][0-9])[0-9]{1,}$", new LengthRangeCheck(14, 19)),
+
+  // Maestro has multiple ranges
+  Maestro("^(?:5018|5020|5038|5893|6304|6759|676[1-3])[0-9]*$", new LengthRangeCheck(12, 19)),
+
+  // JCB can begin with 1800 or 2131 and be 15 digits in length, or
+  // begin with 35 and be 16-19 digits in length.
+  JCB("^(?:2131|1800|35[0-9]{2})[0-9]*$", new LengthRangeCheck(15, 19)),
+
+  // Universal Air Travel Plan numbers start with 1
+  UATP("^1[0-9]{3,}$", new LengthCheck(15));
+
+  /**
+   * Java 8 forward-compatible version of what should be a lambda. Written to compile in Java 7 for
+   * use in Andriod projects.
+   */
+  private static interface Predicate<T> {
+
+    /**
+     * Evaluates this predicate on the given argument.
+     *
+     * @param t the input argument
+     * @return {@code true} if the input argument matches the predicate, otherwise {@code false}
+     */
+    boolean test(T t);
+  }
+
+  private static final class LengthCheck implements Predicate<Integer> {
+
+    private final int[] validLengths;
+
+    LengthCheck(final int... validLengths) {
+      this.validLengths = validLengths;
+    }
+
+    @Override
+    public boolean test(final Integer length) {
+      for (int i = 0; i < validLengths.length; i++) {
+        if (length == validLengths[i]) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+
+  private static final class LengthRangeCheck implements Predicate<Integer> {
+
+    private final int minLength;
+    private final int maxLength;
+
+    LengthRangeCheck(final int minLength, final int maxLength) {
+      this.minLength = minLength;
+      this.maxLength = maxLength;
+    }
+
+    @Override
+    public boolean test(final Integer length) {
+      return length >= minLength && length <= maxLength;
+    }
+  }
 
   public static CardBrand from(final String accountNumber) {
     if (isBlank(accountNumber)) {
@@ -57,8 +137,14 @@ public enum CardBrand {
   }
 
   private final Pattern pattern;
+  private final Predicate<Integer> lengthCheck;
 
-  CardBrand(final String patternRegEx) {
+  CardBrand(final String patternRegEx, final Predicate<Integer> lengthCheck) {
     this.pattern = Pattern.compile(patternRegEx);
+    this.lengthCheck = lengthCheck;
+  }
+
+  public boolean isLengthValid(final int accountNumberLength) {
+    return lengthCheck.test(accountNumberLength);
   }
 }

--- a/src/main/java/us/fatehi/creditcardnumber/ServiceCode.java
+++ b/src/main/java/us/fatehi/creditcardnumber/ServiceCode.java
@@ -1,7 +1,7 @@
 /*
  *
- * Magnetic Track Parser
- * https://github.com/sualeh/magnetictrackparser
+ * Credit Card Number
+ * https://github.com/sualeh/credit_card_number
  * Copyright (c) 2014-2021, Sualeh Fatehi.
  *
  */

--- a/src/main/java/us/fatehi/creditcardnumber/ServiceCode1.java
+++ b/src/main/java/us/fatehi/creditcardnumber/ServiceCode1.java
@@ -1,7 +1,7 @@
 /*
  *
- * Magnetic Track Parser
- * https://github.com/sualeh/magnetictrackparser
+ * Credit Card Number
+ * https://github.com/sualeh/credit_card_number
  * Copyright (c) 2014-2021, Sualeh Fatehi.
  *
  */

--- a/src/main/java/us/fatehi/creditcardnumber/ServiceCode2.java
+++ b/src/main/java/us/fatehi/creditcardnumber/ServiceCode2.java
@@ -1,7 +1,7 @@
 /*
  *
- * Magnetic Track Parser
- * https://github.com/sualeh/magnetictrackparser
+ * Credit Card Number
+ * https://github.com/sualeh/credit_card_number
  * Copyright (c) 2014-2021, Sualeh Fatehi.
  *
  */

--- a/src/main/java/us/fatehi/creditcardnumber/ServiceCode3.java
+++ b/src/main/java/us/fatehi/creditcardnumber/ServiceCode3.java
@@ -1,7 +1,7 @@
 /*
  *
- * Magnetic Track Parser
- * https://github.com/sualeh/magnetictrackparser
+ * Credit Card Number
+ * https://github.com/sualeh/credit_card_number
  * Copyright (c) 2014-2021, Sualeh Fatehi.
  *
  */

--- a/src/main/java/us/fatehi/creditcardnumber/ServiceCodeType.java
+++ b/src/main/java/us/fatehi/creditcardnumber/ServiceCodeType.java
@@ -1,7 +1,7 @@
 /*
  *
- * Magnetic Track Parser
- * https://github.com/sualeh/magnetictrackparser
+ * Credit Card Number
+ * https://github.com/sualeh/credit_card_number
  * Copyright (c) 2014-2021, Sualeh Fatehi.
  *
  */

--- a/src/test/java/us/fatehi/test/creditcardnumber/AccountNumberCompleteTest.java
+++ b/src/test/java/us/fatehi/test/creditcardnumber/AccountNumberCompleteTest.java
@@ -53,7 +53,6 @@ public class AccountNumberCompleteTest {
     assertThat(!pan.passesLuhnCheck(), is(true));
     assertThat(pan.getAccountNumberLength(), is(16));
     check(rawAccountNumber, pan, rawAccountNumber);
-    assertThat(pan.getCardBrand(), is(CardBrand.MasterCard));
     assertThat(pan.isPrimaryAccountNumberValid(), is(false));
   }
 
@@ -65,7 +64,6 @@ public class AccountNumberCompleteTest {
     assertThat(pan.isLengthValid(), is(true));
     assertThat(pan.isPrimaryAccountNumberValid(), is(true));
     assertThat(pan.getAccountNumberLength(), is(16));
-    assertThat(pan.getCardBrand(), is(CardBrand.MasterCard));
     check(rawAccountNumber, pan, rawAccountNumber);
 
     final AccountNumber securePan1 = pan.toSecureAccountNumber();
@@ -86,7 +84,6 @@ public class AccountNumberCompleteTest {
     assertThat(pan.isLengthValid(), is(true));
     assertThat(pan.isPrimaryAccountNumberValid(), is(true));
     assertThat(pan.getAccountNumberLength(), is(16));
-    assertThat(pan.getCardBrand(), is(CardBrand.MasterCard));
     check(rawAccountNumber, pan, accountNumber);
 
     assertThat(pan.toString(), is(accountNumber));
@@ -104,7 +101,6 @@ public class AccountNumberCompleteTest {
     assertThat(pan.isLengthValid(), is(false));
     assertThat(pan.isPrimaryAccountNumberValid(), is(false));
     assertThat(pan.getAccountNumberLength(), is(20));
-    assertThat(pan.getCardBrand(), is(CardBrand.Unknown));
     check(rawAccountNumber, pan, accountNumber);
   }
 
@@ -117,7 +113,6 @@ public class AccountNumberCompleteTest {
     assertThat(pan.isLengthValid(), is(false));
     assertThat(pan.isPrimaryAccountNumberValid(), is(false));
     assertThat(pan.getAccountNumberLength(), is(8));
-    assertThat(pan.getCardBrand(), is(CardBrand.Unknown));
     check(rawAccountNumber, pan, accountNumber);
   }
 
@@ -128,6 +123,9 @@ public class AccountNumberCompleteTest {
     assertThat(pan.getLastFourDigits(), is(right(accountNumber, 4)));
     assertThat(pan.getIssuerIdentificationNumber(), is(left(accountNumber, IIN_LEN)));
     assertThat(pan.getMajorIndustryIdentifier(), is(MajorIndustryIdentifier.mii_5));
+    // Allow look-ahead typing and try to identify the card brand by teh first four digits of the
+    // card number
+    assertThat(pan.getCardBrand(), is(CardBrand.MasterCard));
   }
 }
 

--- a/src/test/java/us/fatehi/test/creditcardnumber/CardBrandTest.java
+++ b/src/test/java/us/fatehi/test/creditcardnumber/CardBrandTest.java
@@ -64,8 +64,7 @@ public class CardBrandTest {
     final long[] longCardNumbers = {
       180072013113445L,
       180015253702997L,
-      210040806417574L,
-      210074314120578L
+        213140806417574L, 213174314120578L
     };
     for (final long longCardNumber : longCardNumbers) {
       test(longCardNumber, CardBrand.JCB);
@@ -216,5 +215,7 @@ public class CardBrandTest {
     final String cardNumber = String.valueOf(longCardNumber);
     final CardBrand cardBrand = CardBrand.from(cardNumber);
     assertThat(cardNumber, cardBrand, is(sameInstance(expectedCardBrand)));
+    assertThat(cardNumber, cardBrand.isLengthValid(String.valueOf(longCardNumber).length()),
+        is(true));
   }
 }

--- a/src/test/java/us/fatehi/test/creditcardnumber/CardBrandTest.java
+++ b/src/test/java/us/fatehi/test/creditcardnumber/CardBrandTest.java
@@ -158,6 +158,14 @@ public class CardBrandTest {
   }
 
   @Test
+  public void rupay() {
+    final long[] longCardNumbers = {6073849000000009L, 6074819900004939L};
+    for (final long longCardNumber : longCardNumbers) {
+      test(longCardNumber, CardBrand.RuPay);
+    }
+  }
+
+  @Test
   public void uatp() {
     final long[] longCardNumbers = {
       168714822757781L,

--- a/src/test/java/us/fatehi/test/creditcardnumber/ServiceCodeTest.java
+++ b/src/test/java/us/fatehi/test/creditcardnumber/ServiceCodeTest.java
@@ -1,7 +1,7 @@
 /*
  *
- * Magnetic Track Parser
- * https://github.com/sualeh/magnetictrackparser
+ * Credit Card Number
+ * https://github.com/sualeh/credit_card_number
  * Copyright (c) 2014-2021, Sualeh Fatehi.
  *
  */


### PR DESCRIPTION
1. Allow type ahead identification od card brands using first four of the card nuumer
2. Allow for rules-based verification of card number length without lambdas, to maintain Java7 compatibility for Android app developers
3. Add MIR and RuPay
4. Update copyright notices